### PR TITLE
Switch to semantic_logger and remove rspec deprecation warnings

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,2 +1,2 @@
-source :rubygems
+source "https://rubygems.org"
 gemspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,70 @@
+PATH
+  remote: .
+  specs:
+    ws_discovery (0.0.3)
+      builder
+      eventmachine
+      nokogiri
+      nori (>= 2.0.0)
+      semantic_logger
+      uuid
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    builder (3.2.2)
+    diff-lcs (1.2.5)
+    docile (1.1.5)
+    eventmachine (1.0.8)
+    json (1.8.3)
+    macaddr (1.7.1)
+      systemu (~> 2.6.2)
+    mini_portile (0.6.2)
+    nokogiri (1.6.6.2)
+      mini_portile (~> 0.6.0)
+    nori (2.6.0)
+    rake (10.4.2)
+    rspec (3.3.0)
+      rspec-core (~> 3.3.0)
+      rspec-expectations (~> 3.3.0)
+      rspec-mocks (~> 3.3.0)
+    rspec-core (3.3.2)
+      rspec-support (~> 3.3.0)
+    rspec-expectations (3.3.1)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.3.0)
+    rspec-mocks (3.3.2)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.3.0)
+    rspec-support (3.3.0)
+    semantic_logger (2.15.0)
+      sync_attr (~> 2.0)
+      thread_safe (~> 0.1)
+    simplecov (0.10.0)
+      docile (~> 1.1.0)
+      json (~> 1.8)
+      simplecov-html (~> 0.10.0)
+    simplecov-html (0.10.0)
+    simplecov-rcov (0.2.3)
+      simplecov (>= 0.4.1)
+    sync_attr (2.0.0)
+    systemu (2.6.5)
+    thread_safe (0.3.5)
+    uuid (2.3.8)
+      macaddr (~> 1.0)
+    yard (0.8.7.6)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  bundler (>= 1.0.21)
+  rake
+  rspec (>= 2.6)
+  simplecov
+  simplecov-rcov
+  ws_discovery!
+  yard (>= 0.7.2)
+
+BUNDLED WITH
+   1.10.6

--- a/lib/ws_discovery/searcher.rb
+++ b/lib/ws_discovery/searcher.rb
@@ -52,7 +52,7 @@ class WSDiscovery::Searcher < WSDiscovery::MulticastConnection
   # send was successful.
   def post_init
     if send_datagram(@search, MULTICAST_IP, MULTICAST_PORT) > 0
-      WSDiscovery::Searcher.log("Sent datagram search:\n#{@search}")
+      logger.info("Sent datagram search:\n#{@search}")
     end
   end
 

--- a/lib/ws_discovery/searcher.rb
+++ b/lib/ws_discovery/searcher.rb
@@ -1,13 +1,11 @@
 require_relative 'multicast_connection'
 require_relative 'response'
+require 'semantic_logger'
 require 'builder'
-require 'log_switch'
 require 'uuid'
 
 class WSDiscovery::Searcher < WSDiscovery::MulticastConnection
-  extend LogSwitch
-  self.logger.datetime_format = "%Y-%m-%d %H:%M:%S "
-
+  include SemanticLogger::Loggable
   # @return [EventMachine::Channel] Provides subscribers with responses from
   #   their search request.
   attr_reader :discovery_responses
@@ -37,7 +35,7 @@ class WSDiscovery::Searcher < WSDiscovery::MulticastConnection
   # @param [String] response The data received on this connection's socket.
   def receive_data(response)
     ip, port = peer_info
-    WSDiscovery::Searcher.log "<#{self.class}> Response from #{ip}:#{port}:\n#{response}\n"
+    logger.info "<#{self.class}> Response from #{ip}:#{port}:\n#{response}\n"
     parsed_response = parse(response)
     @discovery_responses << parsed_response
   end

--- a/spec/ws_discovery/multicast_connection_spec.rb
+++ b/spec/ws_discovery/multicast_connection_spec.rb
@@ -13,45 +13,45 @@ describe WSDiscovery::MulticastConnection do
 
   describe "#peer_info" do
     before do
-      WSDiscovery::MulticastConnection.any_instance.stub(:setup_multicast_socket)
-      subject.stub_chain(:get_peername, :[], :unpack).and_return(%w(1234 1 2 3 4))
+      allow_any_instance_of(WSDiscovery::MulticastConnection).to receive(:setup_multicast_socket)
+      allow(subject).to receive_message_chain(:get_peername, :[], :unpack).and_return(%w(1234 1 2 3 4))
     end
 
     it "returns an Array with IP and port" do
-      subject.send(:peer_info).should == ['1.2.3.4', 1234]
+      expect(subject.send(:peer_info)).to eql ['1.2.3.4', 1234]
     end
 
     it "returns IP as a String" do
-      subject.send(:peer_info).first.should be_a String
+      expect(subject.send(:peer_info).first).to be_a String
     end
 
     it "returns port as a Fixnum" do
-      subject.send(:peer_info).last.should be_a Fixnum
+      expect(subject.send(:peer_info).last).to be_a Fixnum
     end
   end
 
   describe "#setup_multicast_socket" do
     before do
-      WSDiscovery::MulticastConnection.any_instance.stub(:set_membership)
-      WSDiscovery::MulticastConnection.any_instance.stub(:switch_multicast_loop)
-      WSDiscovery::MulticastConnection.any_instance.stub(:set_multicast_ttl)
-      WSDiscovery::MulticastConnection.any_instance.stub(:set_ttl)
+      allow_any_instance_of(WSDiscovery::MulticastConnection).to receive(:set_membership)
+      allow_any_instance_of(WSDiscovery::MulticastConnection).to receive(:switch_multicast_loop)
+      allow_any_instance_of(WSDiscovery::MulticastConnection).to receive(:set_multicast_ttl)
+      allow_any_instance_of(WSDiscovery::MulticastConnection).to receive(:set_ttl)
     end
 
     it "adds 0.0.0.0 and 239.255.255.250 to the membership group" do
-      subject.should_receive(:set_membership).with(
+      expect(subject).to receive(:set_membership).with(
         IPAddr.new('239.255.255.250').hton + IPAddr.new('0.0.0.0').hton
       )
       subject.send(:setup_multicast_socket)
     end
 
     it "sets multicast TTL to 1" do
-      subject.should_receive(:set_multicast_ttl).with(1)
+      expect(subject).to receive(:set_multicast_ttl).with(1)
       subject.send(:setup_multicast_socket)
     end
 
     it "sets TTL to 1" do
-      subject.should_receive(:set_ttl).with(1)
+      expect(subject).to receive(:set_ttl).with(1)
       subject.send(:setup_multicast_socket)
     end
 
@@ -60,7 +60,7 @@ describe WSDiscovery::MulticastConnection do
 
       it "turns multicast loop off" do
         ENV['RUBY_TESTING_ENV'] = "development"
-        subject.should_receive(:switch_multicast_loop).with(:off)
+        expect(subject).to receive(:switch_multicast_loop).with(:off)
         subject.send(:setup_multicast_socket)
       end
     end
@@ -68,32 +68,32 @@ describe WSDiscovery::MulticastConnection do
 
   describe "#switch_multicast_loop" do
     before do
-      WSDiscovery::MulticastConnection.any_instance.stub(:setup_multicast_socket)
+      allow_any_instance_of(WSDiscovery::MulticastConnection).to receive(:setup_multicast_socket)
     end
 
     it "passes '\\001' to the socket option call when param == :on" do
-      subject.should_receive(:set_sock_opt).with(
+      expect(subject).to receive(:set_sock_opt).with(
         0, Socket::IP_MULTICAST_LOOP, "\001"
       )
       subject.send(:switch_multicast_loop, :on)
     end
 
     it "passes '\\001' to the socket option call when param == '\\001'" do
-      subject.should_receive(:set_sock_opt).with(
+      expect(subject).to receive(:set_sock_opt).with(
         0, Socket::IP_MULTICAST_LOOP, "\001"
       )
       subject.send(:switch_multicast_loop,"\001")
     end
 
     it "passes '\\000' to the socket option call when param == :off" do
-      subject.should_receive(:set_sock_opt).with(
+      expect(subject).to receive(:set_sock_opt).with(
         0, Socket::IP_MULTICAST_LOOP, "\000"
       )
       subject.send(:switch_multicast_loop,:off)
     end
 
     it "passes '\\000' to the socket option call when param == '\\000'" do
-      subject.should_receive(:set_sock_opt).with(
+      expect(subject).to receive(:set_sock_opt).with(
         0, Socket::IP_MULTICAST_LOOP, "\000"
       )
       subject.send(:switch_multicast_loop,"\000")

--- a/spec/ws_discovery/response_spec.rb
+++ b/spec/ws_discovery/response_spec.rb
@@ -63,7 +63,7 @@ describe WSDiscovery::Response do
 
   describe "#[]" do
     it "should return the SOAP response body as a Hash" do
-      subject[:probe_matches].should == probe_body_hash[:probe_matches]
+      expect(subject[:probe_matches]).to eql probe_body_hash[:probe_matches]
     end
 
     it "should throw an exception when the response body isn't parsable" do
@@ -73,7 +73,7 @@ describe WSDiscovery::Response do
 
   describe "#header" do
     it "should return the SOAP response header as a Hash" do
-      subject.header[:app_sequence].should == probe_header_hash[:app_sequence]
+      expect(subject.header[:app_sequence]).to eql probe_header_hash[:app_sequence]
     end
 
     it "should throw an exception when the response header isn't parsable" do
@@ -84,35 +84,35 @@ describe WSDiscovery::Response do
   %w(body to_hash).each do |method|
     describe "##{method}" do
       it "should return the SOAP response body as a Hash" do
-        subject.send(method)[:probe_matches].should == probe_body_hash[:probe_matches]
+        expect(subject.send(method)[:probe_matches]).to eql probe_body_hash[:probe_matches]
       end
     end
   end
 
   describe "#hash" do
     it "should return the complete SOAP response XML as a Hash" do
-      subject.hash.should == probe_full_hash
+      expect(subject.hash).to eql probe_full_hash
     end
   end
 
   describe "#to_xml" do
     it "should return the raw SOAP response body" do
-      subject.to_xml.should == probe_response
+      expect(subject.to_xml).to eql probe_response
     end
   end
 
   describe "#doc" do
     it "returns a Nokogiri::XML::Document for the SOAP response XML" do
-      subject.doc.should be_a(Nokogiri::XML::Document)
+      expect(subject.doc).to be_a(Nokogiri::XML::Document)
     end
   end
 
   describe "#xpath" do
     it "permits XPath access to elements in the request" do
-      subject.xpath("//a:Address").first.inner_text.
-        should == "urn:uuid:0b679890-fc54-14ba-d428-f73b3e7c2400"
-      subject.xpath("//d:ProbeMatch/d:XAddrs").first.inner_text.
-        should == "http://10.221.222.74/onvif/device_service"
+      expect(subject.xpath("//a:Address").first.inner_text).to \
+        eql "urn:uuid:0b679890-fc54-14ba-d428-f73b3e7c2400"
+      expect(subject.xpath("//d:ProbeMatch/d:XAddrs").first.inner_text).to \
+        eql "http://10.221.222.74/onvif/device_service"
     end
   end
 end

--- a/spec/ws_discovery/searcher_spec.rb
+++ b/spec/ws_discovery/searcher_spec.rb
@@ -20,9 +20,8 @@ describe WSDiscovery::Searcher do
   end
 
   before do
-    WSDiscovery::Searcher.log = false
-    WSDiscovery::MulticastConnection.any_instance.stub(:setup_multicast_socket)
-    UUID.stub(:generate).and_return('a-uuid')
+    allow_any_instance_of(WSDiscovery::MulticastConnection).to receive(:setup_multicast_socket)
+    allow(UUID).to receive(:generate).and_return('a-uuid')
   end
 
   subject do
@@ -31,8 +30,7 @@ describe WSDiscovery::Searcher do
 
   describe "#initialize" do
     it "does a #probe" do
-      WSDiscovery::Searcher.any_instance.should_receive(:probe)
-
+      expect_any_instance_of(WSDiscovery::Searcher).to receive(:probe)
       subject
     end
   end
@@ -44,11 +42,11 @@ describe WSDiscovery::Searcher do
 
     it "takes a response and adds it to the list of responses" do
       response = double 'response'
-      subject.stub(:peer_info).and_return(['0.0.0.0', 4567])
+      allow(subject).to receive(:peer_info).and_return(['0.0.0.0', 4567])
 
-      subject.should_receive(:parse).with(response).exactly(1).times.
+      expect(subject).to receive(:parse).with(response).exactly(1).times.
         and_return(parsed_response)
-      subject.instance_variable_get(:@discovery_responses).should_receive(:<<).
+      expect(subject.instance_variable_get(:@discovery_responses)).to receive(:<<).
         with(parsed_response)
 
       subject.receive_data(response)
@@ -57,20 +55,20 @@ describe WSDiscovery::Searcher do
 
   describe "#parse" do
     before do
-      WSDiscovery::MulticastConnection.any_instance.stub(:setup_multicast_socket)
+      allow_any_instance_of(WSDiscovery::MulticastConnection).to receive(:setup_multicast_socket)
     end
 
     it "turns probe matches into WSDiscovery::Responses" do
       result = subject.parse "<Envelope />"
-      result.should be_a WSDiscovery::Response
+      expect(result).to be_a WSDiscovery::Response
     end
   end
 
   describe "#post_init" do
-    before { WSDiscovery::Searcher.any_instance.stub(:m_search).and_return("hi") }
+    before { allow_any_instance_of(WSDiscovery::Searcher).to receive(:m_search).and_return("hi") }
 
     it "sends a probe as a datagram over 239.255.255.250:3702" do
-      subject.should_receive(:send_datagram).
+      expect(subject).to receive(:send_datagram).
         with(default_probe, '239.255.255.250', 3702).
         and_return 0
       subject.post_init
@@ -79,9 +77,9 @@ describe WSDiscovery::Searcher do
 
   describe "#probe" do
     it "builds the probe string using the given parameters" do
-      subject.probe(
+      expect(subject.probe(
         env_namespaces: { "xmlns:dn" => "http://www.onvif.org/ver10/network/wsdl" },
-        types: "dn:NetworkVideoTransmitter").should == <<-PROBE.strip
+        types: "dn:NetworkVideoTransmitter")).to eql <<-PROBE.strip
 <s:Envelope xmlns:a=\"http://schemas.xmlsoap.org/ws/2004/08/addressing\" xmlns:\
 d=\"http://schemas.xmlsoap.org/ws/2005/04/discovery\" xmlns:s=\"http://www.w3.o\
 rg/2003/05/soap-envelope\" xmlns:dn=\"http://www.onvif.org/ver10/network/wsdl\"\

--- a/spec/ws_discovery_spec.rb
+++ b/spec/ws_discovery_spec.rb
@@ -7,33 +7,33 @@ describe WSDiscovery do
   describe '.search' do
     let(:multicast_searcher) do
       searcher = double "WSDiscovery::Searcher"
-      searcher.stub_chain(:discovery_responses, :subscribe).and_yield(%w[one two])
+      allow(searcher).to receive_message_chain(:discovery_responses, :subscribe).and_yield(%w[one two])
 
       searcher
     end
 
     before do
-      EM.stub(:run).and_yield
-      EM.stub(:add_timer)
-      EM.stub(:open_datagram_socket).and_return multicast_searcher
+      allow(EM).to receive(:run).and_yield
+      allow(EM).to receive(:add_timer)
+      allow(EM).to receive(:open_datagram_socket).and_return multicast_searcher
     end
 
     context "reactor is already running" do
       it "returns a WSDiscovery::Searcher" do
-        EM.stub(:reactor_running?).and_return true
-        subject.search.should == multicast_searcher
+        allow(EM).to receive(:reactor_running?).and_return true
+        expect(subject.search).to eql multicast_searcher
       end
     end
 
     context "reactor is not already running" do
       it "returns an Array of responses" do
-        EM.stub(:add_shutdown_hook).and_yield
-        subject.search.should == %w[one two]
+        allow(EM).to receive(:add_shutdown_hook).and_yield
+        expect(subject.search).to eql %w[one two]
       end
 
       it "opens a UDP socket on '0.0.0.0', port 0" do
-        EM.stub(:add_shutdown_hook)
-        EM.should_receive(:open_datagram_socket).with('0.0.0.0', 0,
+        allow(EM).to receive(:add_shutdown_hook)
+        expect(EM).to receive(:open_datagram_socket).with('0.0.0.0', 0,
           WSDiscovery::Searcher, {})
         subject.search
       end

--- a/ws_discovery.gemspec
+++ b/ws_discovery.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency("bundler", ">= 1.0.21")
   s.add_development_dependency("rake", ">= 0")
-  s.add_development_dependency("rspec", "~> 2.6")
+  s.add_development_dependency("rspec", ">= 2.6")
   s.add_development_dependency("simplecov", ">= 0")
   s.add_development_dependency("simplecov-rcov", ">= 0")
   s.add_development_dependency("yard", ">= 0.7.2")

--- a/ws_discovery.gemspec
+++ b/ws_discovery.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency("builder")
   s.add_dependency("eventmachine")
-  s.add_dependency("log_switch", ">=0.1.4")
+  s.add_dependency("semantic_logger")
   s.add_dependency("nokogiri")
   s.add_dependency("nori", '>=2.0.0')
   s.add_dependency("uuid")


### PR DESCRIPTION
It appears log_switch is a dead project. The documentation is not up to date an the developer is not responsive - I have switched to the widely used semantic_logger.

I have also removed all rspec deprecation warnings and following the new expect/allow syntax.

No breaking changes were made so please merge with master :)